### PR TITLE
Get the test_scheduler tests passing.

### DIFF
--- a/src/scheduler/tests/test_scheduler.py
+++ b/src/scheduler/tests/test_scheduler.py
@@ -11,15 +11,13 @@ from .utils import advance_testclock
 
 
 def create_entry(name, priority, start, stop, interval, action):
-    temp_user = User.objects.get_or_create(email='iwork@ntia.doc.gov')[0]
-
     kwargs = {
         'name': name,
         'priority': priority,
         'stop': stop,
         'interval': interval,
         'action': action,
-        'owner': temp_user
+        'owner': User.objects.get_or_create(username='test')[0]
     }
 
     if start is not None:


### PR DESCRIPTION
The problem is in the `create_entry` function. ScheduleEntry objects now need assigned users, which at not allowed to be NULL. To compensate for this dependency, create a global user who will own all of the tested entries. Then put the user under the `kwargs` dic, with the key `'owner'`, in the `create_entry` function. This should solve all failures on this test.