### PR TITLE
SMSS-128 and SMSS-129

### DIFF
--- a/src/requirements-dev.txt
+++ b/src/requirements-dev.txt
@@ -1,6 +1,8 @@
 -rrequirements.txt
 
+flake8==3.5.0
 mkdocs==0.16.3
 pytest-cov==2.5.1
 pytest-django==3.1.2
+pytest-flake8==0.9.1
 tox==2.7.0

--- a/src/tox.ini
+++ b/src/tox.ini
@@ -11,7 +11,7 @@ passenv =
     DEBUG
     DOMAINS
     IPS
-commands = py.test --junitxml=junit-{envname}.xml {posargs}
+commands = py.test {posargs}
 install_command = pip install {opts} {packages}
 list_dependencies_command = pip freeze
 
@@ -19,7 +19,6 @@ list_dependencies_command = pip freeze
 basepython = python2
 deps =
     -r{toxinidir}/requirements-dev.txt
-    flake8
 commands =
     python -m flake8 .
 
@@ -27,15 +26,20 @@ commands =
 basepython = python2
 deps =
     -r{toxinidir}/requirements-dev.txt
-     pytest-cov
-commands = py.test --cov-report term-missing --cov=src tests
+commands = py.test --cov-report term-missing --cov
+
+[testenv:jenkins]
+basepython = python2
+deps =
+    -r{toxinidir}/requirements-dev.txt
+commands = - py.test --flake8 --cov --junitxml=test_results/junit.xml --cov-report term-missing --cov-report xml:test_results/coverage.xml
 
 [flake8]
 exclude =
     .tox
     ./sigmf
-    ./*/migrations
     ./sensor/settings.py
+    */migrations/*
 
 [pytest]
 DJANGO_SETTINGS_MODULE = sensor.settings


### PR DESCRIPTION
Added tox environment for jenkins to run tests, flake8, coverage. Moved dependencies to requirements-dev.txt. Removed junit output from default tox command. Fixed tox coverage command.