### PR TITLE
Inline autoheal so that we can use it on ARM

### DIFF
--- a/docker/autoheal-entrypoint
+++ b/docker/autoheal-entrypoint
@@ -1,0 +1,54 @@
+#!/bin/bash
+
+# Docker-autoheal is inlined from https://github.com/willfarrell/docker-autoheal
+# so that we can run in on ARM
+
+set -e
+
+DOCKER_SOCK=${DOCKER_SOCK:-/var/run/docker.sock}
+TMP_DIR=/tmp/restart
+
+apt-get update && apt-get install -y curl jq
+
+if [ -e ${DOCKER_SOCK} ]; then
+
+    rm -rf "$TMP_DIR"
+    mkdir "$TMP_DIR"
+
+    # https://docs.docker.com/engine/api/v1.25/
+
+    # Set container selector
+    if [ "$AUTOHEAL_CONTAINER_LABEL" == "all" ]; then
+        selector() {
+            jq -r '.[].Id'
+        }
+    else
+        selector() {
+            jq -r '.[] | select(.Labels["'${AUTOHEAL_CONTAINER_LABEL:=autoheal}'"] == "true") | .Id'
+        }
+    fi
+
+    echo "Monitoring containers for unhealthy status"
+    while true; do
+        sleep ${AUTOHEAL_INTERVAL:=5}
+
+        CONTAINERS=$(curl --no-buffer -s -XGET --unix-socket ${DOCKER_SOCK} http://localhost/containers/json | selector)
+        for CONTAINER in $CONTAINERS; do
+            HEALTH=$(curl --no-buffer -s -XGET --unix-socket ${DOCKER_SOCK} http://localhost/containers/${CONTAINER}/json | jq -r .State.Health.Status)
+            if [ "unhealthy" = "$HEALTH" ]; then
+                DATE=$(date +%d-%m-%Y" "%H:%M:%S)
+                echo "$DATE Container ${CONTAINER:0:12} found to be unhealthy"
+                touch "$TMP_DIR/$CONTAINER"
+            fi
+        done
+        for CONTAINER in `ls $TMP_DIR`; do
+            DATE=$(date +%d-%m-%Y" "%H:%M:%S)
+            echo "$DATE Restarting container ${CONTAINER:0:12}"
+            curl -f --no-buffer -s -XPOST --unix-socket ${DOCKER_SOCK} http://localhost/containers/${CONTAINER}/restart && rm "$TMP_DIR/$CONTAINER" || echo "$DATE Restarting container ${CONTAINER:0:12} failed"
+        done
+    done
+
+else
+    echo "Docker socket doesn't exist"
+    exit 1
+fi

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -55,9 +55,11 @@ services:
   # https://github.com/moby/moby/issues/28400
   # https://github.com/willfarrell/docker-autoheal
   autoheal:
-    restart: always
-    image: willfarrell/autoheal
+    image: ${UBUNTU_IMAGE}
+    restart: on-failure
     depends_on:
       - api
     volumes:
-      - /var/run/docker.sock:/tmp/docker.sock
+      - /var/run/docker.sock:/var/run/docker.sock
+      - ./autoheal-entrypoint:/autoheal-entrypoint:ro
+    command: /autoheal-entrypoint

--- a/env.template
+++ b/env.template
@@ -21,13 +21,21 @@ DEBUG=false
 DOMAINS="$(hostname -d) $(hostname -s).local localhost"
 IPS="$(hostname -I) 127.0.0.1"
 
-# Uncomment the correct ubuntu docker image for your arch
-UBUNTU_IMAGE=ubuntu
-#UBUNTU_IMAGE=arm32v7/ubuntu
-
-# Uncomment the correct nginx docker image for your arch
-NGINX_IMAGE=nginx
-#NGINX_IMAGE=armhfbuild/nginx
+case "$(uname -p)" in
+    x86_64)
+        echo "Detected architecture x86_64"
+        UBUNTU_IMAGE=ubuntu
+        NGINX_IMAGE=nginx
+        ;;
+    armv7*)
+        echo "Detected architecture armv7"
+        UBUNTU_IMAGE=arm32v7/ubuntu
+        NGINX_IMAGE=arm32v7/nginx
+        ;;
+    *)
+        echo "Unrecognized architecture in `uname -p`." >&2
+        exit 1
+esac
 
 # SECURITY WARNING: You should be using certs from a trusted authority.
 #                   If you don't have any, try letsencrypt or a similar service.

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -13,6 +13,7 @@ REPO_ROOT=$(git rev-parse --show-toplevel)
 # To avoid substituting nginx variables, which also use the shell syntax,
 # specify only the variables that will be used in our nginx config: Populate
 # nginx config template to get an actual nginx config
+
 echo "Writing ${REPO_ROOT}/nginx/conf.d/scos-sensor.conf"
 mkdir -p ${REPO_ROOT}/nginx/conf.d
 envsubst '$DOMAINS' \


### PR DESCRIPTION
This PR inlines `autoheal` so that we can run it in an image that's arm-compatible if need be.

I've also automated the detection of x86 vs arm by looking at the output `uname -p` instead of requiring the user to set that manually.

Below is a test run on x86, manually unplugging and replugging the USRP. You can see it takes 2 restarts, but then the api image is return to healthy status.

```bash
$ docker-compose -p scossensor logs --tail 10 -f autoheal
Attaching to scossensor_autoheal_1
autoheal_1  | Hit:1 http://archive.ubuntu.com/ubuntu xenial InRelease
autoheal_1  | Get:2 http://archive.ubuntu.com/ubuntu xenial-updates InRelease [102 kB]
autoheal_1  | Hit:3 http://security.ubuntu.com/ubuntu xenial-security InRelease
autoheal_1  | Get:4 http://archive.ubuntu.com/ubuntu xenial-backports InRelease [102 kB]
autoheal_1  | Get:5 http://archive.ubuntu.com/ubuntu xenial-updates/main amd64 Packages [864 kB]
autoheal_1  | Fetched 1068 kB in 1s (939 kB/s)
autoheal_1  | Reading package lists...
autoheal_1  | Reading package lists...
autoheal_1  | Building dependency tree...
autoheal_1  | Reading state information...
autoheal_1  | jq is already the newest version (1.5+dfsg-1).
autoheal_1  | curl is already the newest version (7.47.0-1ubuntu2.4).
autoheal_1  | 0 upgraded, 0 newly installed, 0 to remove and 1 not upgraded.
autoheal_1  | Monitoring containers for unhealthy status
[... after a few minutes ...]
autoheal_1  | 27-11-2017 19:27:53 Container b7288ddc6d68 found to be unhealthy
autoheal_1  | 27-11-2017 19:27:53 Restarting container b7288ddc6d68
autoheal_1  | 27-11-2017 19:28:29 Container b7288ddc6d68 found to be unhealthy
autoheal_1  | 27-11-2017 19:28:29 Restarting container b7288ddc6d68
[... wait a few minutes to ensure no more restarts ...]
```