### PR TITLE
Makes a couple of small changes to env.template.

### DIFF
--- a/env.template
+++ b/env.template
@@ -3,9 +3,6 @@
 # Copy env.template to env and modify
 
 
-# Save shell flags
-flags=$(set +o)
-
 # Mark all the following variables for export
 set -o allexport
 
@@ -22,19 +19,15 @@ DOMAINS="$(hostname -d) $(hostname -s).local localhost"
 IPS="$(hostname -I) 127.0.0.1"
 
 case "$(uname -p)" in
-    x86_64)
-        echo "Detected architecture x86_64"
-        UBUNTU_IMAGE=ubuntu
-        NGINX_IMAGE=nginx
-        ;;
     armv7*)
         echo "Detected architecture armv7"
         UBUNTU_IMAGE=arm32v7/ubuntu
         NGINX_IMAGE=arm32v7/nginx
         ;;
     *)
-        echo "Unrecognized architecture in `uname -p`." >&2
-        exit 1
+        echo "Non-armv7 architecture detected"
+        UBUNTU_IMAGE=ubuntu
+        NGINX_IMAGE=nginx
 esac
 
 # SECURITY WARNING: You should be using certs from a trusted authority.
@@ -49,6 +42,3 @@ if $DEBUG; then
 else
     GUNICORN_LOG_LEVEL=info;
 fi
-
-# Restore shell flags
-eval "$flags"


### PR DESCRIPTION
This PR makes env.template drop down to default settings for the `UBUNTU` and `NGINX` variables in `env.template`, and removes shell flag saving and loading, as it causes problems in some terminals.