### PR TITLE
Add link to license in readme.

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,3 +43,7 @@ REST API Reference
    - [Security](docs/api/openapi.adoc#_securityscheme)
 
  - [Download PDF](https://github.com/NTIA/scos-sensor/raw/master/docs/api/openapi.pdf)
+ 
+ License
+ -------
+ See [LICENSE.md](LICENSE.md).


### PR DESCRIPTION
We were going to add a separate disclaimer, but it seems like the LICENSE takes care of everything.