### PR TITLE
Make new serializer tests significantly more useful and fix issue

### DIFF
--- a/src/schedule/serializers.py
+++ b/src/schedule/serializers.py
@@ -1,10 +1,24 @@
+from datetime import datetime
+
 from rest_framework import serializers
 from rest_framework.reverse import reverse
 
 import actions
 from sensor import V1
-from sensor.utils import get_datetime_from_timestamp
+from sensor.utils import (
+    get_datetime_from_timestamp,
+    get_timestamp_from_datetime
+)
 from .models import ScheduleEntry
+
+
+def datetimes_to_timestamps(validated_data):
+    """Covert datetimes to timestamp integers in validated_data."""
+    for k, v in validated_data.items():
+        if type(v) is datetime:
+            validated_data[k] = get_timestamp_from_datetime(v)
+
+    return validated_data
 
 
 class ScheduleEntrySerializer(serializers.HyperlinkedModelSerializer):
@@ -133,3 +147,13 @@ class ScheduleEntrySerializer(serializers.HyperlinkedModelSerializer):
 
         # py2.7 compat -> super().to_internal...
         return super(ScheduleEntrySerializer, self).to_representation(obj)
+
+    def create(self, validated_data):
+        """Convert datetime to timestamp integers."""
+        validated_data = datetimes_to_timestamps(validated_data)
+        return super(ScheduleEntrySerializer, self).create(validated_data)
+
+    def update(self, instance, validated_data):
+        validated_data = datetimes_to_timestamps(validated_data)
+        parent = super(ScheduleEntrySerializer, self)
+        return parent.update(instance, validated_data)

--- a/src/schedule/tests/test_serializers.py
+++ b/src/schedule/tests/test_serializers.py
@@ -42,11 +42,15 @@ from .utils import post_schedule
     },
     # 'stop' and 'absolute_stop' are synonyms
     {'name': 'test', 'action': 'logger', 'stop': '2018-03-16T17:12:35.0Z'},
-
+    # Subseconds are optional
+    {'name': 'test', 'action': 'logger', 'start': '2018-03-16T17:12:35Z'},
+    # sensor is timezone-aware
+    {'name': 'test', 'action': 'logger', 'start': '2018-03-22T13:53:25-06:00'},
 ])
-def test_valid_entries(entry_json):
+def test_valid_entries(entry_json, user):
     serializer = ScheduleEntrySerializer(data=entry_json)
     assert serializer.is_valid()
+    serializer.save(owner=user)  # if input is valid, model should accept it
 
 
 # Test that invalid input is invalid

--- a/src/sensor/utils.py
+++ b/src/sensor/utils.py
@@ -7,6 +7,11 @@ def get_datetime_from_timestamp(ts):
     return datetime.fromtimestamp(ts)
 
 
+def get_timestamp_from_datetime(dt):
+    """Assumes UTC datetime."""
+    return int(dt.strftime("%s"))
+
+
 def get_datetime_str_now():
     return datetime.isoformat(datetime.utcnow()) + 'Z'
 


### PR DESCRIPTION
New datetime string start and stop fields on schedule entry were passing serializer validation but not being translated into the correct format to pass to the model. This PR fixes that.