### PR TITLE
Use environment variable to enable mock usrp

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -36,6 +36,8 @@ services:
       - DOCKER_TAG
       - GIT_BRANCH
       - IN_DOCKER=1
+      # Uncomment to use mock USRP
+      # - MOCK=1
     expose:
       - '8000'
     volumes:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -36,8 +36,7 @@ services:
       - DOCKER_TAG
       - GIT_BRANCH
       - IN_DOCKER=1
-      # Uncomment to use mock USRP
-      # - MOCK=1
+      - MOCK_RADIO
     expose:
       - '8000'
     volumes:

--- a/src/hardware/usrp_iface.py
+++ b/src/hardware/usrp_iface.py
@@ -37,7 +37,7 @@ def connect(sf_file=settings.SCALE_FACTORS_FILE):  # -> bool:
     global is_available
     global radio
 
-    if settings.RUNNING_DEMO or settings.RUNNING_TESTS or settings.MOCK:
+    if settings.RUNNING_DEMO or settings.RUNNING_TESTS or settings.MOCK_RADIO:
         logger.warning("Using mock USRP.")
 
         usrp = MockUsrpBlock()

--- a/src/hardware/usrp_iface.py
+++ b/src/hardware/usrp_iface.py
@@ -36,8 +36,8 @@ def connect(sf_file=settings.SCALE_FACTORS_FILE):  # -> bool:
     global uhd
     global is_available
     global radio
-
-    if settings.RUNNING_DEMO or settings.RUNNING_TESTS:
+    
+    if settings.RUNNING_DEMO or settings.RUNNING_TESTS or settings.MOCK:
         logger.warning("Using mock USRP.")
 
         usrp = MockUsrpBlock()

--- a/src/hardware/usrp_iface.py
+++ b/src/hardware/usrp_iface.py
@@ -36,7 +36,7 @@ def connect(sf_file=settings.SCALE_FACTORS_FILE):  # -> bool:
     global uhd
     global is_available
     global radio
-    
+
     if settings.RUNNING_DEMO or settings.RUNNING_TESTS or settings.MOCK:
         logger.warning("Using mock USRP.")
 

--- a/src/sensor/settings.py
+++ b/src/sensor/settings.py
@@ -37,7 +37,7 @@ __cmd = path.split(sys.argv[0])[-1]
 IN_DOCKER = bool(environ.get('IN_DOCKER'))
 RUNNING_TESTS = 'test' in __cmd
 RUNNING_DEMO = bool(environ.get('DEMO'))
-MOCK = bool(environ.get('MOCK'))
+MOCK_RADIO = bool(environ.get('MOCK_RADIO'))
 
 # Healthchecks - the existance of any of these indicates an unhealthy state
 SDR_HEALTHCHECK_FILE = path.join(REPO_ROOT, 'sdr_unhealthy')

--- a/src/sensor/settings.py
+++ b/src/sensor/settings.py
@@ -37,6 +37,7 @@ __cmd = path.split(sys.argv[0])[-1]
 IN_DOCKER = bool(environ.get('IN_DOCKER'))
 RUNNING_TESTS = 'test' in __cmd
 RUNNING_DEMO = bool(environ.get('DEMO'))
+MOCK = bool(environ.get('MOCK'))
 
 # Healthchecks - the existance of any of these indicates an unhealthy state
 SDR_HEALTHCHECK_FILE = path.join(REPO_ROOT, 'sdr_unhealthy')


### PR DESCRIPTION
This pull request adds an environment variable called MOCK. When MOCK is true, the mock USRP will be used instead of the gnuradio USRP.

This will be useful for testing scos-c2, datastore, and client without relying on an actual sensor.