### PR TITLE
Bug: Floor division of a negative number

### DIFF
--- a/src/hardware/gps_iface.py
+++ b/src/hardware/gps_iface.py
@@ -91,16 +91,16 @@ def get_lat_long(timeout_s=1):
         if ns == 'S':
             latitude = -latitude
 
-        latitude_degs = int(latitude / 100)
-        latitude_mins = latitude - (latitude_degs * 100)
+        latitude_degs = int(latitude // 100)
+        latitude_mins = latitude - (latitude_degs)
         latitude_dd = latitude_degs + (latitude_mins / 60)
 
         longitude = float(lng)
         if ew == 'W':
             longitude = -longitude
 
-        longitude_degs = int(longitude / 100)
-        longitude_mins = longitude - (longitude_degs * 100)
+        longitude_degs = int(longitude // 100)
+        longitude_mins = longitude - (longitude_degs)
         longitude_dd = longitude_degs + (longitude_mins / 60)
     except ValueError as err:
         logger.error("Got invalid GPGGA sentence from GPS - {}".format(err))

--- a/src/hardware/gps_iface.py
+++ b/src/hardware/gps_iface.py
@@ -86,7 +86,7 @@ def get_lat_long(timeout_s=1):
         gpgga = usrp.get_mboard_sensor('gps_gpgga').value
         (fmt, utc, lat, ns, lng, ew, qual, nsats, hdil, alt, altu, gdalsep,
          gdalsepu, age, refid) = gpgga.split(',')
-        
+
         latitude = float(lat)
         if ns == 'S':
             latitude = -latitude

--- a/src/hardware/gps_iface.py
+++ b/src/hardware/gps_iface.py
@@ -93,7 +93,7 @@ def get_lat_long(timeout_s=1):
         if ns == 'S':
             latitude = -latitude
 
-        latitude_degs = int(latitude / 100)
+        latitude_degs = int(latitude // 100)
         latitude_mins = latitude - (latitude_degs * 100)
         latitude_dd = latitude_degs + (latitude_mins / 60)
 
@@ -101,7 +101,7 @@ def get_lat_long(timeout_s=1):
         if ew == 'W':
             longitude = -longitude
 
-        longitude_degs = int(longitude / 100)
+        longitude_degs = int(longitude // 100)
         longitude_mins = longitude - (longitude_degs * 100)
         longitude_dd = longitude_degs + (longitude_mins / 60)
     except ValueError as err:

--- a/src/hardware/gps_iface.py
+++ b/src/hardware/gps_iface.py
@@ -91,16 +91,16 @@ def get_lat_long(timeout_s=1):
         if ns == 'S':
             latitude = -latitude
 
-        latitude_degs = int(latitude // 100)
-        latitude_mins = latitude - (latitude_degs)
+        latitude_degs = int(latitude / 100)
+        latitude_mins = latitude - (latitude_degs * 100)
         latitude_dd = latitude_degs + (latitude_mins / 60)
 
         longitude = float(lng)
         if ew == 'W':
             longitude = -longitude
 
-        longitude_degs = int(longitude // 100)
-        longitude_mins = longitude - (longitude_degs)
+        longitude_degs = int(longitude / 100)
+        longitude_mins = longitude - (longitude_degs * 100)
         longitude_dd = longitude_degs + (longitude_mins / 60)
     except ValueError as err:
         logger.error("Got invalid GPGGA sentence from GPS - {}".format(err))

--- a/src/hardware/gps_iface.py
+++ b/src/hardware/gps_iface.py
@@ -87,42 +87,21 @@ def get_lat_long(timeout_s=1):
         (fmt, utc, lat, ns, lng, ew, qual, nsats, hdil, alt, altu, gdalsep,
          gdalsepu, age, refid) = gpgga.split(',')
         
-        print("GPS NMEA: {}".format(gpgga))
-        
         latitude = float(lat)
-        
-        print ("GPS Original Latitude:", latitude)
-        
         if ns == 'S':
             latitude = -latitude
-        
-        print ("GPS Converted Latitude:", latitude)
 
-        latitude_degs = int(latitude // 100)
+        latitude_degs = int(latitude / 100)
         latitude_mins = latitude - (latitude_degs * 100)
         latitude_dd = latitude_degs + (latitude_mins / 60)
-        
-        print ("GPS Latitude Degs:", latitude_degs)
-        print ("GPS Latitude Mins:", latitude_mins)
-        print ("GPS Latitude DD:", latitude_dd)
 
         longitude = float(lng)
-        
-        print ("GPS Original Longitude:", longitude)
-        
         if ew == 'W':
             longitude = -longitude
-            
-        print ("GPS Converted Longitude:", longitude)
 
-        longitude_degs = int(longitude // 100)
+        longitude_degs = int(longitude / 100)
         longitude_mins = longitude - (longitude_degs * 100)
         longitude_dd = longitude_degs + (longitude_mins / 60)
-        
-        print ("GPS Longitude Degs:", longitude_degs)
-        print ("GPS Longitude Mins:", longitude_mins)
-        print ("GPS Longitude DD:", longitude_dd)
-        
     except ValueError as err:
         logger.error("Got invalid GPGGA sentence from GPS - {}".format(err))
         return None

--- a/src/hardware/gps_iface.py
+++ b/src/hardware/gps_iface.py
@@ -89,22 +89,40 @@ def get_lat_long(timeout_s=1):
         
         print("GPS NMEA: {}".format(gpgga))
         
-        
         latitude = float(lat)
+        
+        print ("GPS Original Latitude:", latitude)
+        
         if ns == 'S':
             latitude = -latitude
+        
+        print ("GPS Converted Latitude:", latitude)
 
         latitude_degs = int(latitude // 100)
         latitude_mins = latitude - (latitude_degs * 100)
         latitude_dd = latitude_degs + (latitude_mins / 60)
+        
+        print ("GPS Latitude Degs:", latitude_degs)
+        print ("GPS Latitude Mins:", latitude_mins)
+        print ("GPS Latitude DD:", latitude_dd)
 
         longitude = float(lng)
+        
+        print ("GPS Original Longitude:", longitude)
+        
         if ew == 'W':
             longitude = -longitude
+            
+        print ("GPS Converted Longitude:", longitude)
 
         longitude_degs = int(longitude // 100)
         longitude_mins = longitude - (longitude_degs * 100)
         longitude_dd = longitude_degs + (longitude_mins / 60)
+        
+        print ("GPS Longitude Degs:", longitude_degs)
+        print ("GPS Longitude Mins:", longitude_mins)
+        print ("GPS Longitude DD:", longitude_dd)
+        
     except ValueError as err:
         logger.error("Got invalid GPGGA sentence from GPS - {}".format(err))
         return None

--- a/src/hardware/gps_iface.py
+++ b/src/hardware/gps_iface.py
@@ -89,6 +89,7 @@ def get_lat_long(timeout_s=1):
         
         print("GPS NMEA: {}".format(gpgga))
         
+        
         latitude = float(lat)
         if ns == 'S':
             latitude = -latitude

--- a/src/hardware/gps_iface.py
+++ b/src/hardware/gps_iface.py
@@ -86,7 +86,9 @@ def get_lat_long(timeout_s=1):
         gpgga = usrp.get_mboard_sensor('gps_gpgga').value
         (fmt, utc, lat, ns, lng, ew, qual, nsats, hdil, alt, altu, gdalsep,
          gdalsepu, age, refid) = gpgga.split(',')
-
+        
+        print("GPS NMEA: {}".format(gpgga))
+        
         latitude = float(lat)
         if ns == 'S':
             latitude = -latitude

--- a/src/hardware/gps_iface.py
+++ b/src/hardware/gps_iface.py
@@ -91,7 +91,7 @@ def get_lat_long(timeout_s=1):
         if ns == 'S':
             latitude = -latitude
 
-        latitude_degs = int(latitude // 100)
+        latitude_degs = int(latitude / 100)
         latitude_mins = latitude - (latitude_degs * 100)
         latitude_dd = latitude_degs + (latitude_mins / 60)
 
@@ -99,7 +99,7 @@ def get_lat_long(timeout_s=1):
         if ew == 'W':
             longitude = -longitude
 
-        longitude_degs = int(longitude // 100)
+        longitude_degs = int(longitude / 100)
         longitude_mins = longitude - (longitude_degs * 100)
         longitude_dd = longitude_degs + (longitude_mins / 60)
     except ValueError as err:


### PR DESCRIPTION
Should not use `int(longitude // 100)` but rather `int(longitude / 100)`. When the longitude is west of the prime meridian, the longitude is written as a negative number. Floor division (`//`)  of a negative number does not give the same result as flooring a positive number and then adding a negative sign:

```
>>> (1234.5678 // 100)
12.0
>>> (-1234.5678 // 100)
-13.0
>>> -(1234.5678 // 100)
-12.0
```

Also changing latitude calculation for consistency / potential southern hemisphere issue.