### PR TITLE
DH "latest" = GH "master" fix

### DIFF
--- a/puppet/manifests/clone.pp
+++ b/puppet/manifests/clone.pp
@@ -13,14 +13,23 @@ inherits scos
     ensure => running,
     enable => true,
   }
-
-  vcsrepo { $install_root:
-    ensure   => latest, # Will use latest commit
-    provider => git,
-    source   => "https://${git_username}:${git_password}@github.com/NTIA/scos-sensor.git",
-    revision => $install_version,
-    notify   => Exec['cleanup'],
-  }
+  
+  if $install_version['latest'] {
+    vcsrepo { $install_root:
+      ensure   => latest, # Will use latest commit
+      provider => git,
+      source   => "https://${git_username}:${git_password}@github.com/NTIA/scos-sensor.git",
+      revision => master,
+      notify   => Exec['cleanup'],
+      } 
+  else {
+    vcsrepo { $install_root:
+      ensure   => latest, # Will use latest commit
+      provider => git,
+      source   => "https://${git_username}:${git_password}@github.com/NTIA/scos-sensor.git",
+      revision => $install_version,
+      notify   => Exec['cleanup'],
+      }
 
 # Trigger cleanup if source changes
 


### PR DESCRIPTION
Github doens't understand `latest` in terms of a Dockerhub tag, so manually mapping `latest` to `master`.