### PR TITLE
Yaml defined schedule entries

### DIFF
--- a/configs/schedule/README.md
+++ b/configs/schedule/README.md
@@ -1,0 +1,27 @@
+# YAML-Defined Schedule Initialization
+
+To pre-load a schedule state from config files, add the following to a file ending in `.yml` in this directory.
+
+```yaml
+entry_name:
+  action: action_name
+  owner: username
+```
+
+The above fields are required, but any other `ScheduleEntry` object fields can be specified as well.
+
+A full example, which will create a private entry performing the `monitor_usrp` action as user `admin` every `60` seconds, would be:
+
+```yaml
+# File: monitor_usrp.yml
+
+monitor_usrp:
+  action: monitor_usrp
+  owner: admin
+  is_private: true
+  interval: 60
+```
+
+## Known Issues
+
+- [ ] Because the entry is created outside of a request context, the `callback_url` field is not currently valid in yaml-defined schedule entries

--- a/configs/schedule/monitor_usrp.yml
+++ b/configs/schedule/monitor_usrp.yml
@@ -1,0 +1,5 @@
+monitor_usrp:
+  action: monitor_usrp
+  owner: admin
+  is_private: true
+  interval: 60

--- a/gunicorn/config.py
+++ b/gunicorn/config.py
@@ -28,6 +28,9 @@ def post_worker_init(worker):
     import django
     django.setup()
 
+    import schedule
+    schedule.init()
+
     from scheduler import scheduler
     scheduler.thread.start()
 

--- a/src/schedule/__init__.py
+++ b/src/schedule/__init__.py
@@ -1,0 +1,76 @@
+"""Initialize schedule state from YAML config files."""
+
+import logging
+from pathlib import Path
+
+from rest_framework.serializers import ValidationError
+from ruamel.yaml import YAML
+
+from sensor import settings
+
+
+logger = logging.getLogger(__name__)
+
+
+def load_from_yaml(yaml_dir=settings.SCHEDULE_ENTRIES_DIR):
+    """Load any YAML files in yaml_dir."""
+
+    import actions
+    from authentication.models import User
+    from schedule.models import ScheduleEntry
+    from schedule.serializers import ScheduleEntrySerializer
+
+    yaml = YAML(typ='safe')
+    yaml_path = Path(yaml_dir)
+    for yaml_file in yaml_path.glob('*.yml'):
+        entry = yaml.load(yaml_file)
+        for name, parameters in entry.items():
+            if ScheduleEntry.objects.filter(name=name):
+                msg = "Entry with name {!r} already exists in schedule"
+                msg += ", skipping"
+                logger.info(msg.format(name))
+                continue
+
+            parameters['name'] = name
+
+            # if 'callback_url' in parameters:
+            #     err = "`callback_url` cannot be used with the YAML-loader. "
+            #     err += "Generating the TaskResult that is sent to the "
+            #     err += "callback_url requires a request context."
+            #     logger.error(err)
+            #     raise RuntimeError(err)
+
+            try:
+                username = parameters.pop('owner')
+                owner = User.objects.get(username=username)
+            except KeyError as exc:
+                err = "Required key 'owner' not specified in {!r}"
+                logger.error(err.format(yaml_file.name))
+                logger.exception(exc)
+                raise exc
+            except User.DoesNotExist as exc:
+                err = "Owner {!r} referenced in {!r} does not exist"
+                logger.error(err.format(username, yaml_file.name))
+                logger.exception(exc)
+                raise exc
+
+            choices = actions.CHOICES
+            if owner.is_staff:
+                choices += actions.ADMIN_CHOICES
+
+
+            deserializer = ScheduleEntrySerializer(data=parameters)
+            try:
+                deserializer.is_valid(raise_exception=True)
+            except ValidationError as exc:
+                err = "Invalid schedule entry parameters specified in {!r}"
+                logger.error(err.format(yaml_file.name))
+                logger.exception(exc)
+                raise exc
+
+            deserializer.save(request=None, owner=owner)
+
+
+def init():
+    """Run schedule initialization routines."""
+    load_from_yaml()

--- a/src/schedule/__init__.py
+++ b/src/schedule/__init__.py
@@ -58,7 +58,6 @@ def load_from_yaml(yaml_dir=settings.SCHEDULE_ENTRIES_DIR):
             if owner.is_staff:
                 choices += actions.ADMIN_CHOICES
 
-
             deserializer = ScheduleEntrySerializer(data=parameters)
             try:
                 deserializer.is_valid(raise_exception=True)

--- a/src/schedule/models/schedule_entry.py
+++ b/src/schedule/models/schedule_entry.py
@@ -127,7 +127,7 @@ class ScheduleEntry(models.Model):
         help_text="The name of the user who owns the entry")
     request = models.ForeignKey(
         'schedule.Request',
-        null=True,  # null allowable for unit testing only
+        null=True,   # may be null for unit testing or for yaml-defined entries
         editable=False,
         on_delete=models.CASCADE,
         help_text="The request that created the entry")

--- a/src/schedule/tests/test_serializers.py
+++ b/src/schedule/tests/test_serializers.py
@@ -1,6 +1,7 @@
 import pytest
 
-from schedule.serializers import ScheduleEntrySerializer
+from schedule.serializers import (
+    AdminScheduleEntrySerializer, ScheduleEntrySerializer)
 from sensor.utils import parse_datetime_str
 
 from .utils import post_schedule
@@ -10,7 +11,7 @@ from .utils import post_schedule
 #
 
 
-# Test that valid input is valid
+# Test that valid user input is valid
 @pytest.mark.django_db
 @pytest.mark.parametrize(
     'entry_json',
@@ -97,13 +98,112 @@ from .utils import post_schedule
             'validate_only': False
         },
     ])
-def test_valid_entries(entry_json, user):
+def test_valid_user_entries(entry_json, user):
     serializer = ScheduleEntrySerializer(data=entry_json)
     assert serializer.is_valid()
     serializer.save(owner=user)  # if input is valid, model should accept it
 
 
-# Test that invalid input is invalid
+# Test that valid admin input is valid
+@pytest.mark.django_db
+@pytest.mark.parametrize(
+    'entry_json',
+    [
+        # A name and action should be the minimum acceptable entry
+        # i.e., (one-shot, ASAP)
+        {
+            'name': 'test',
+            'action': 'logger'
+        },
+        # Stop 10 seconds after starting, start ASAP
+        {
+            'name': 'test',
+            'action': 'logger',
+            'relative_stop': 10
+        },
+        # Min integer interval ok
+        {
+            'name': 'test',
+            'action': 'logger',
+            'interval': 10
+        },
+        # Max priority ok
+        {
+            'name': 'test',
+            'action': 'logger',
+            'priority': 19
+        },
+        # Min admin priority ok
+        {
+            'name': 'test',
+            'action': 'logger',
+            'priority': -20
+        },
+        # Stop 10 seconds after starting; start at absolute time
+        {
+            'name': 'test',
+            'action': 'logger',
+            'start': '2018-03-16T17:12:25Z',
+            'relative_stop': 10,
+        },
+        # Start and stop at absolute time; equivalent to above
+        {
+            'name': 'test',
+            'action': 'logger',
+            'start': '2018-03-16T17:12:25Z',
+            'absolute_stop': '2018-03-16T17:12:35Z',
+        },
+        # 'stop' and 'absolute_stop' are synonyms
+        {
+            'name': 'test',
+            'action': 'logger',
+            'stop': '2018-03-16T17:12:35.0Z'
+        },
+        # Subseconds are optional
+        {
+            'name': 'test',
+            'action': 'logger',
+            'start': '2018-03-16T17:12:35Z'
+        },
+        # Sensor is timezone-aware
+        {
+            'name': 'test',
+            'action': 'logger',
+            'start': '2018-03-22T13:53:25-06:00'
+        },
+        # All non-boolean, non-required fields accepts null to mean not defined
+        {
+            'name': 'test',
+            'action': 'logger',
+            'start': None,
+            'absolute_stop': None,
+            'relative_stop': None,
+            'priority': None,
+            'start': None,
+            'start': None,
+            'interval': None,
+            'callback_url': None,
+        },
+        # Explicit validate_only is valid
+        {
+            'name': 'test',
+            'action': 'logger',
+            'validate_only': False
+        },
+        # Admin can create private entries
+        {
+            'name': 'test',
+            'action': 'logger',
+            'is_private': True
+        }
+    ])
+def test_valid_admin_entries(entry_json, user):
+    serializer = AdminScheduleEntrySerializer(data=entry_json)
+    assert serializer.is_valid()
+    serializer.save(owner=user)  # if input is valid, model should accept it
+
+
+# Test that invalid user input is invalid
 @pytest.mark.django_db
 @pytest.mark.parametrize(
     'entry_json',
@@ -122,7 +222,7 @@ def test_valid_entries(entry_json, user):
             'action': 'logger',
             'priority': 3.14
         },
-        # negative priority (for normal user)
+        # priority less than min (for normal user)
         {
             'name': 'test',
             'action': 'logger',
@@ -191,10 +291,105 @@ def test_valid_entries(entry_json, user):
             'action': 'logger',
             'start': '2018-03-16T17:12:35Z',
             'stop': '2018-03-16T17:12:35Z',
+        }
+    ])
+def test_invalid_user_entries(entry_json):
+    serializer = ScheduleEntrySerializer(data=entry_json)
+    assert not serializer.is_valid()
+
+
+# Test that invalid admin input is invalid
+@pytest.mark.django_db
+@pytest.mark.parametrize(
+    'entry_json',
+    [
+        # name is a required field
+        {
+            'action': 'logger'
+        },
+        # action is a required field
+        {
+            'name': 'test'
+        },
+        # non-integer priority
+        {
+            'name': 'test',
+            'action': 'logger',
+            'priority': 3.14
+        },
+        # priority less than min (for admin)
+        {
+            'name': 'test',
+            'action': 'logger',
+            'priority': -21
+        },
+        # priority greater than max (19)
+        {
+            'name': 'test',
+            'action': 'logger',
+            'priority': 20
+        },
+        # non-integer interval
+        {
+            'name': 'test',
+            'action': 'logger',
+            'interval': 3.14
+        },
+        # zero interval
+        {
+            'name': 'test',
+            'action': 'logger',
+            'interval': 0
+        },
+        # negative interval
+        {
+            'name': 'test',
+            'action': 'logger',
+            'interval': -1
+        },
+        # can't interpret both absolute and relative stop
+        {
+            'name': 'test',
+            'action': 'logger',
+            'start': '2018-03-16T17:12:25.0Z',
+            'absolute_stop': '2018-03-16T17:12:35.0Z',
+            'relative_stop': 10,
+        },
+        # 0 relative_stop
+        {
+            'name': 'test',
+            'action': 'logger',
+            'relative_stop': 0
+        },
+        # negative relative_stop
+        {
+            'name': 'test',
+            'action': 'logger',
+            'relative_stop': -10
+        },
+        # non-integer relative_stop
+        {
+            'name': 'test',
+            'action': 'logger',
+            'relative_stop': 3.14
+        },
+        # stop is before start
+        {
+            'name': 'test',
+            'action': 'logger',
+            'start': '2018-03-16T17:12:35Z',
+            'stop': '2018-03-16T17:12:30Z'
+        },
+        # stop is same as start
+        {
+            'name': 'test',
+            'action': 'logger',
+            'start': '2018-03-16T17:12:35Z',
+            'stop': '2018-03-16T17:12:35Z',
         },
     ])
-def test_invalid_entries(entry_json):
-    serializer = ScheduleEntrySerializer(data=entry_json)
+def test_invalid_admin_entries(entry_json):
+    serializer = AdminScheduleEntrySerializer(data=entry_json)
     assert not serializer.is_valid()
 
 

--- a/src/schedule/tests/utils.py
+++ b/src/schedule/tests/utils.py
@@ -32,7 +32,8 @@ def post_schedule(client, entry, expected_status=status.HTTP_201_CREATED):
         'wsgi.url_scheme': 'https'
     }
 
-    r = client.post(reverse('schedule-list', kwargs=V1), **kwargs)
+    url = reverse('schedule-list', kwargs=V1)
+    r = client.post(url, **kwargs)
 
     err = "Got status {}, expected {}".format(r.status_code, expected_status)
     assert r.status_code == expected_status, err

--- a/src/sensor/settings.py
+++ b/src/sensor/settings.py
@@ -57,10 +57,11 @@ OPENAPI_FILE = path.join(REPO_ROOT, 'docs', 'openapi.json')
 
 CONFIG_DIR = path.join(REPO_ROOT, 'configs')
 
-# JSON configs
+# YAML/JSON config paths
 SCALE_FACTORS_FILE = path.join(CONFIG_DIR, 'scale_factors.json')
 SENSOR_DEFINITION_FILE = path.join(CONFIG_DIR, 'sensor_definition.json')
 ACTION_DEFINITIONS_DIR = path.join(CONFIG_DIR, 'actions')
+SCHEDULE_ENTRIES_DIR = path.join(CONFIG_DIR, 'schedule')
 
 # Cleanup any existing healtcheck files
 try:


### PR DESCRIPTION
TODO:
 - [ ] is_private had no effect
 - [ ] does schedule entry still need a Request context stored with it? The
 yaml-defined schedule entries do not have a valid request context to attach.
 Work around or remove?
 - [ ] `callback_url` also cannot be used without a request context
 - [ ] unit tests for `load_from_yaml` needed