### PR TITLE
Fix static files error

### DIFF
--- a/src/requirements.txt
+++ b/src/requirements.txt
@@ -1,4 +1,4 @@
-Django==2.2.1
+Django==2.2.2
 Pygments==2.4.2
 Markdown==3.1.1
 -e git+https://github.com/NTIA/SigMF.git@multi-recording-archive#egg=SigMF

--- a/src/sensor/settings.py
+++ b/src/sensor/settings.py
@@ -33,12 +33,6 @@ else:
 
 STATIC_ROOT = path.join(BASE_DIR, "static")
 STATIC_URL = "/static/"
-STATICFILES_DIRS = (
-    # ("js", path.join(STATIC_ROOT, "js")),
-    # ("css", path.join(STATIC_ROOT, "css")),
-    # ("images", path.join(STATIC_ROOT, "images")),
-    # ("fonts", path.join(STATIC_ROOT, "fonts")),
-)
 
 __cmd = path.split(sys.argv[0])[-1]
 IN_DOCKER = bool(environ.get("IN_DOCKER"))

--- a/src/sensor/settings.py
+++ b/src/sensor/settings.py
@@ -34,10 +34,10 @@ else:
 STATIC_ROOT = path.join(BASE_DIR, "static")
 STATIC_URL = "/static/"
 STATICFILES_DIRS = (
-    ("js", path.join(STATIC_ROOT, "js")),
-    ("css", path.join(STATIC_ROOT, "css")),
-    ("images", path.join(STATIC_ROOT, "images")),
-    ("fonts", path.join(STATIC_ROOT, "fonts")),
+    # ("js", path.join(STATIC_ROOT, "js")),
+    # ("css", path.join(STATIC_ROOT, "css")),
+    # ("images", path.join(STATIC_ROOT, "images")),
+    # ("fonts", path.join(STATIC_ROOT, "fonts")),
 )
 
 __cmd = path.split(sys.argv[0])[-1]


### PR DESCRIPTION
This PR fixes two issues. 
1. Commented out the entries in STATICFILES_DIRS. These directories do not exist. The debug toolbar is throwing error for being unable to locate these directories.
2. Update Django version for security vulnerability CVE-2019-12308