### PR TITLE
Update m4s action

### DIFF
--- a/src/.isort.cfg
+++ b/src/.isort.cfg
@@ -4,4 +4,4 @@ include_trailing_comma=True
 force_grid_wrap=0
 use_parentheses=True
 line_length=88
-known_third_party=django,drf_yasg,jsonfield,numpy,pytest,requests_futures,requests_mock,rest_framework,ruamel,sigmf
+known_third_party=django,drf_yasg,environs,jsonfield,numpy,pytest,requests_futures,requests_mock,rest_framework,ruamel,scipy,sigmf

--- a/src/actions/acquire_single_freq_fft.py
+++ b/src/actions/acquire_single_freq_fft.py
@@ -47,10 +47,10 @@ $$
 
 where $a_{{i,j}}$ is a complex time-domain sample.
 
-At the point, a Flat Top window, defined as
+At that point, a Flat Top window, defined as
 
-$$w(n) &= 0.2156 - 0.4160 \cos{{(2 \pi n / M)}} + 0.2781 \cos{{(4 \pi n / M)}} -
-       & 0.0836 \cos{{(6 \pi n / M)}} + 0.0069 \cos{{(8 \pi n / M)}}$$
+$$w(n) = &0.2156 - 0.4160 \cos{{(2 \pi n / M)}} + 0.2781 \cos{{(4 \pi n / M)}} -
+         &0.0836 \cos{{(6 \pi n / M)}} + 0.0069 \cos{{(8 \pi n / M)}}$$
 
 where $M = {fft_size}$ is the number of points in the window, is applied to
 each row of the matrix.
@@ -63,18 +63,30 @@ an FFT, doing the equivalent of the DFT defined as
 $$A_k = \sum_{{m=0}}^{{n-1}}
 a_m \exp\left\\{{-2\pi i{{mk \over n}}\right\\}} \qquad k = 0,\ldots,n-1$$
 
-The data matrix is then converted to power by taking the square of the
-magnitude of each complex sample individually. The resulting matrix is
-real-valued, 32-bit floats representing dBm.
+The data matrix is then converted to pseudo-power by taking the square of the
+magnitude of each complex sample individually, allowing power statistics to be
+taken.
 
 ## Applying detector
 
-Lastly, the M4S (min, max, mean, median, and sample) detector is applied to the
+Next, the M4S (min, max, mean, median, and sample) detector is applied to the
 data matrix. The input to the detector is a matrix of size ${nffts} \times
 {fft_size}$, and the output matrix is size $5 \times {fft_size}$, with the
 first row representing the min of each _column_, the second row representing
 the _max_ of each column, and so "sample" detector simple chooses one of the
 {nffts} FFTs at random.
+
+## Power conversion
+
+To finish the power conversion, the samples are divided by the characteristic
+impedance (50 ohms). The power is then referenced back to the RF power by
+dividing further by 2. The powers are normalized to the FFT bin width by
+dividing by the length of the FFT and converted to dBm. Finally, an FFT window
+correction factor is added to the powers given by
+
+$$ C_{{win}} = 20log \left( \frac{{1}}{{ mean \left( w(n) \right) }} \right)
+
+The resulting matrix is real-valued, 32-bit floats representing dBm.
 
 """
 

--- a/src/actions/acquire_single_freq_fft.py
+++ b/src/actions/acquire_single_freq_fft.py
@@ -47,9 +47,10 @@ $$
 
 where $a_{{i,j}}$ is a complex time-domain sample.
 
-At the point, a Blackman window, defined as
+At the point, a Flat Top window, defined as
 
-$$w(n) = 0.42 - 0.5 \cos{{(2 \pi n / M)}} + 0.08 \cos{{(4 \pi n / M)}}$$
+$$w(n) &= 0.2156 - 0.4160 \cos{{(2 \pi n / M)}} + 0.2781 \cos{{(4 \pi n / M)}} -
+       & 0.0836 \cos{{(6 \pi n / M)}} + 0.0069 \cos{{(8 \pi n / M)}}$$
 
 where $M = {fft_size}$ is the number of points in the window, is applied to
 each row of the matrix.
@@ -240,7 +241,7 @@ class SingleFrequencyFftAcquisition(Action):
             frequency_domain_detection_md = {
                 "ntia-core:annotation_type": "FrequencyDomainDetection",
                 "ntia-algorithm:number_of_samples_in_fft": self.fft_size,
-                "ntia-algorithm:window": "blackman",
+                "ntia-algorithm:window": "flattop",
                 "ntia-algorithm:equivalent_noise_bandwidth": self.enbw,
                 "ntia-algorithm:detector": detector.name + "_power",
                 "ntia-algorithm:number_of_ffts": self.nffts,

--- a/src/actions/utils.py
+++ b/src/actions/utils.py
@@ -1,0 +1,38 @@
+import numpy as np
+from scipy.signal import windows
+
+
+def get_fft_window(window_type, window_length):
+    # Generate the window with the right number of points
+    window = None
+    if window_type == "Bartlett":
+        window = windows.bartlett(window_length)
+    if window_type == "Blackman":
+        window = windows.blackman(window_length)
+    if window_type == "Blackman Harris":
+        window = windows.blackmanharris(window_length)
+    if window_type == "Flat Top":
+        window = windows.flattop(window_length)
+    if window_type == "Hamming":
+        window = windows.hamming(window_length)
+    if window_type == "Hanning":
+        window = windows.hann(window_length)
+
+    # If no window matched, use a rectangular window
+    if window is None:
+        window = np.ones(window_length)
+
+    # Return the window
+    return window
+
+
+def get_fft_window_correction(window, correction_type="amplitude"):
+    # Calculate the requested correction factor
+    window_correction = 1  # Assume no correction
+    if correction_type == "amplitude":
+        window_correction = 1 / np.mean(window)
+    if correction_type == "energy":
+        window_correction = np.sqrt(1 / np.mean(window ** 2))
+
+    # Return the window correction factor
+    return window_correction

--- a/src/environment.yml
+++ b/src/environment.yml
@@ -26,6 +26,7 @@ dependencies:
   - requests-futures=0.9.9
   - requests-mock=1.6.0
   - ruamel.yaml=0.15.96
+  - scipy=1.3.1
   - six=1.12.0
   - pip
   - pip:
@@ -39,6 +40,3 @@ dependencies:
     - psycopg2-binary==2.8.2
     - seed-isort-config==1.9.1
     - tox==3.12.1
-
-
-

--- a/src/requirements.txt
+++ b/src/requirements.txt
@@ -18,5 +18,6 @@ raven==6.10.0
 requests-futures==0.9.9
 requests-mock==1.6.0
 ruamel.yaml==0.15.96
+scipy==1.3.1
 six==1.12.0
 typing==3.6.6


### PR DESCRIPTION
- Updated the M4+S action to use a flat top window with amplitude correction
- Translated power back to the original RF signal instead of the complex envelope.
- Changed the calculated ENBW to reflect the ENBW for the FFT bins instead of the relative ENBW of the window.
- Added an FFT window function to allow utilizing different windows easier (required additional library: scipy)