### PR TITLE
Fix Ubuntu version to 18.04

### DIFF
--- a/docker/Dockerfile-api
+++ b/docker/Dockerfile-api
@@ -1,4 +1,4 @@
-FROM ubuntu
+FROM ubuntu:18.04
 
 # Copy just the necessities from our PY3-enabled UHD container
 COPY --from=smsntia/uhd_b2xx_py3:3.13.1.0-rc1 /usr/local/lib/libuhd.so* /usr/local/lib/

--- a/docker/Dockerfile-uhd
+++ b/docker/Dockerfile-uhd
@@ -1,4 +1,4 @@
-FROM ubuntu as build
+FROM ubuntu:18.04 as build
 
 # Everything AFTER the "v" in the GitHub tag
 ARG UHD_TAG=3.13.1.0-rc1

--- a/docker/Dockerfile-uhd
+++ b/docker/Dockerfile-uhd
@@ -20,7 +20,7 @@ RUN cmake -DENABLE_PYTHON_API=ON -DENABLE_PYTHON3=ON ../
 RUN make && make test && make install
 RUN python3 /usr/local/lib/uhd/utils/uhd_images_downloader.py
 
-FROM ubuntu
+FROM ubuntu:18.04
 
 # Copy just the necessities to run B2xx with python3
 COPY --from=build /usr/local/lib/libuhd.so* /usr/local/lib/

--- a/src/requirements.txt
+++ b/src/requirements.txt
@@ -13,7 +13,7 @@ environs==4.2.0
 gunicorn==19.9.0
 jsonfield==2.0.2
 numpy>=1.16.4
-psycopg2-binary==2.8.2
+psycopg2-binary==2.8.5
 python-dateutil==2.8.1
 raven==6.10.0
 requests-futures==0.9.9


### PR DESCRIPTION
The Dockerfile-api is set to use the latest version of Ubuntu. One of the package dependencies is not able to be installed in the new version of Ubuntu - 20.04. Setting the Ubuntu version back to 18.04 until package dependency issue is resolved.