### PR TITLE
Add Missing Ubuntu Packages in Dockerfile

### DIFF
--- a/docker/Dockerfile-api
+++ b/docker/Dockerfile-api
@@ -9,7 +9,7 @@ RUN apt-get update -q && \
                    libboost-serialization1.65.1 libboost-system1.65.1 \
                    libboost-thread1.65.1 libusb-1.0-0 libpython3.7 \
                    libboost-program-options1.65.1 \
-                   git python3.7 \
+                   git python3-pip python3-setuptools python3.7 \
 		   swig gcc python3.7-dev && \
     apt-get clean && rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
Dockerfile-api commands are dependent on python3-pip and python3-setuptools packages which were not installed (unless in base image). Modified Dockerfile-api to install these packages.