### PR TITLE
Update data archive path in download script

### DIFF
--- a/scripts/data_download.sh
+++ b/scripts/data_download.sh
@@ -38,7 +38,7 @@ if [ $doublecheck == "y" ]; then
     printf "Copy started: `date` \n"
     for i in $(seq $firstfile $lastfile); do
         start=$SECONDS
-        curl -o $filepath/$schedule\_$i.sigmf -kLsS -H "Authorization: Token $token" https://$ip/api/v1/acquisitions/$schedule/$i/archive
+        curl -o $filepath/$schedule\_$i.sigmf -kLsS -H "Authorization: Token $token" https://$ip/api/v1/tasks/completed/$schedule/$i/archive
         remaining=$(( (((SECONDS - start) * (lastfile - firstfile - i) / 60) + remaining) / 2 ))
         printf "Downloaded ${schedule}_${i}.sigmf. ${remaining} mins remaining. \n"
     done


### PR DESCRIPTION
Fixes #212 by updating the path to the data archives in the download script.

The fix works, tested on `seadog01` sensor.