### PR TITLE
Update SCOS Actions to 4.0.2

### DIFF
--- a/src/actions/__init__.py
+++ b/src/actions/__init__.py
@@ -2,7 +2,7 @@ import importlib
 import logging
 import pkgutil
 
-from scos_actions.actions.interfaces.signals import register_action
+from scos_actions.signals import register_action
 from scos_actions.discover import test_actions
 
 from sensor import settings

--- a/src/requirements-dev.txt
+++ b/src/requirements-dev.txt
@@ -273,7 +273,7 @@ scipy==1.9.0
     # via
     #   -r requirements.txt
     #   scos-actions
-scos_actions @ git+https://github.com/NTIA/scos-actions@4.0.1
+scos_actions @ git+https://github.com/NTIA/scos-actions@4.0.2
     # via
     #   -r requirements.txt
     #   scos-usrp

--- a/src/requirements.in
+++ b/src/requirements.in
@@ -11,5 +11,5 @@ psycopg2-binary>=2.0, <3.0
 pyjwt>=2.4.0, <3.0
 requests-mock>=1.0, <2.0
 requests_oauthlib>=1.0, <2.0
-scos_actions @ git+https://github.com/NTIA/scos-actions@4.0.1#egg=scos_actions
+scos_actions @ git+https://github.com/NTIA/scos-actions@4.0.2#egg=scos_actions
 scos_usrp @ git+https://github.com/NTIA/scos-usrp@2.0.0

--- a/src/requirements.txt
+++ b/src/requirements.txt
@@ -146,7 +146,7 @@ ruamel-yaml-clib==0.2.6
     # via ruamel-yaml
 scipy==1.9.0
     # via scos-actions
-scos_actions @ git+https://github.com/NTIA/scos-actions@4.0.1
+scos_actions @ git+https://github.com/NTIA/scos-actions@4.0.2
     # via
     #   -r requirements.in
     #   scos-usrp

--- a/src/utils/action_registrar.py
+++ b/src/utils/action_registrar.py
@@ -1,6 +1,6 @@
 from collections import OrderedDict
 
-from scos_actions.actions.interfaces.signals import register_action
+from scos_actions.signals import register_action
 
 registered_actions = OrderedDict()
 


### PR DESCRIPTION
Update imports and requirements for SCOS Actions 4.0.2, accounting for the relocation of the `signals` file within the `scos_actions` package.