### PR TITLE
Dependency updates: scos-actions 6.2.2, scos-tekrsa 3.0.4, tekrsa-api-wrap 1.3.2

### DIFF
--- a/src/requirements-dev.txt
+++ b/src/requirements-dev.txt
@@ -300,11 +300,11 @@ scipy==1.10.1
     # via
     #   -r requirements.txt
     #   scos-actions
-scos_actions @ git+https://github.com/NTIA/scos-actions@6.2.1
+scos_actions @ git+https://github.com/NTIA/scos-actions@6.2.2
     # via
     #   -r requirements.txt
     #   scos-tekrsa
-scos_tekrsa @ git+https://github.com/NTIA/scos-tekrsa@3.0.3
+scos_tekrsa @ git+https://github.com/NTIA/scos-tekrsa@api-wrapper-1.3.2
     # via -r requirements.txt
 sigmf @ git+https://github.com/NTIA/SigMF@multi-recording-archive
     # via
@@ -324,7 +324,7 @@ sqlparse==0.4.3
     # via
     #   -r requirements.txt
     #   django
-tekrsa-api-wrap==1.3.1
+tekrsa-api-wrap==1.3.2
     # via
     #   -r requirements.txt
     #   scos-tekrsa

--- a/src/requirements-dev.txt
+++ b/src/requirements-dev.txt
@@ -304,7 +304,7 @@ scos_actions @ git+https://github.com/NTIA/scos-actions@6.2.2
     # via
     #   -r requirements.txt
     #   scos-tekrsa
-scos_tekrsa @ git+https://github.com/NTIA/scos-tekrsa@api-wrapper-1.3.2
+scos_tekrsa @ git+https://github.com/NTIA/scos-tekrsa@3.0.4
     # via -r requirements.txt
 sigmf @ git+https://github.com/NTIA/SigMF@multi-recording-archive
     # via

--- a/src/requirements.in
+++ b/src/requirements.in
@@ -15,4 +15,4 @@ pyjwt>=2.4.0, <3.0
 requests-mock>=1.0, <2.0
 requests_oauthlib>=1.0, <2.0
 scos_actions @ git+https://github.com/NTIA/scos-actions@6.2.2
-scos_tekrsa @ git+https://github.com/NTIA/scos-tekrsa@api-wrapper-1.3.2
+scos_tekrsa @ git+https://github.com/NTIA/scos-tekrsa@3.0.4

--- a/src/requirements.in
+++ b/src/requirements.in
@@ -14,5 +14,5 @@ psycopg2-binary>=2.0, <3.0
 pyjwt>=2.4.0, <3.0
 requests-mock>=1.0, <2.0
 requests_oauthlib>=1.0, <2.0
-scos_actions @ git+https://github.com/NTIA/scos-actions@6.2.1
-scos_tekrsa @ git+https://github.com/NTIA/scos-tekrsa@3.0.3
+scos_actions @ git+https://github.com/NTIA/scos-actions@6.2.2
+scos_tekrsa @ git+https://github.com/NTIA/scos-tekrsa@api-wrapper-1.3.2

--- a/src/requirements.txt
+++ b/src/requirements.txt
@@ -180,11 +180,11 @@ ruamel-yaml-clib==0.2.7
     # via ruamel-yaml
 scipy==1.10.1
     # via scos-actions
-scos_actions @ git+https://github.com/NTIA/scos-actions@6.2.1
+scos_actions @ git+https://github.com/NTIA/scos-actions@6.2.2
     # via
     #   -r requirements.in
     #   scos-tekrsa
-scos_tekrsa @ git+https://github.com/NTIA/scos-tekrsa@3.0.3
+scos_tekrsa @ git+https://github.com/NTIA/scos-tekrsa@api-wrapper-1.3.2
     # via -r requirements.in
 sigmf @ git+https://github.com/NTIA/SigMF@multi-recording-archive
     # via scos-actions
@@ -199,7 +199,7 @@ six==1.16.0
     #   websocket-client
 sqlparse==0.4.3
     # via django
-tekrsa-api-wrap==1.3.1
+tekrsa-api-wrap==1.3.2
     # via scos-tekrsa
 texttable==1.6.7
     # via docker-compose

--- a/src/requirements.txt
+++ b/src/requirements.txt
@@ -184,7 +184,7 @@ scos_actions @ git+https://github.com/NTIA/scos-actions@6.2.2
     # via
     #   -r requirements.in
     #   scos-tekrsa
-scos_tekrsa @ git+https://github.com/NTIA/scos-tekrsa@api-wrapper-1.3.2
+scos_tekrsa @ git+https://github.com/NTIA/scos-tekrsa@3.0.4
     # via -r requirements.in
 sigmf @ git+https://github.com/NTIA/SigMF@multi-recording-archive
     # via scos-actions


### PR DESCRIPTION
- Update dependencies to make use of changes and fixes in NTIA/scos-actions#74, NTIA/scos-tekrsa#41, and NTIA/tekrsa-api-wrap#16

Changes are tested and working on seadog01.