### PR TITLE
Fix scheduling future actions

### DIFF
--- a/src/sensor/tests/test_sensor_utils.py
+++ b/src/sensor/tests/test_sensor_utils.py
@@ -1,0 +1,20 @@
+from datetime import datetime
+
+from django.conf import settings
+
+from sensor import utils
+
+
+def test_timestamp_manipulation():
+    now = datetime.now()
+    now_int = int(now.timestamp())
+    now_fromint = datetime.fromtimestamp(now_int)
+    now_str = now.strftime(settings.DATETIME_FORMAT)
+
+    test_dt_int = utils.get_timestamp_from_datetime(now)
+    test_dt_fromint = utils.get_datetime_from_timestamp(now_int)
+    test_dt_fromstr = utils.parse_datetime_str(now_str)
+
+    assert now_int == test_dt_int
+    assert now_fromint == test_dt_fromint
+    assert now == test_dt_fromstr

--- a/src/sensor/utils.py
+++ b/src/sensor/utils.py
@@ -9,16 +9,16 @@ from django.conf import settings
 logger = logging.getLogger(__name__)
 
 
-def get_datetime_from_timestamp(ts):
+def get_datetime_from_timestamp(ts: int) -> datetime:
     return datetime.fromtimestamp(ts)
 
 
-def get_timestamp_from_datetime(dt: datetime):
+def get_timestamp_from_datetime(dt: datetime) -> int:
     """Assumes UTC datetime."""
     return int(dt.timestamp())
 
 
-def parse_datetime_str(d):
+def parse_datetime_str(d: str) -> datetime:
     return datetime.strptime(d, settings.DATETIME_FORMAT)
 
 

--- a/src/sensor/utils.py
+++ b/src/sensor/utils.py
@@ -15,7 +15,7 @@ def get_datetime_from_timestamp(ts):
 
 def get_timestamp_from_datetime(dt: datetime):
     """Assumes UTC datetime."""
-    return int(dt.strftime("%S"))
+    return int(dt.timestamp())
 
 
 def parse_datetime_str(d):


### PR DESCRIPTION
Fixes #233 and #234 and adds unit tests to avoid similar bugs in the future.

The bug was introduced in #230 by changing a `strftime` format flag from `"%s"` to `"%S"`, based on warnings which occurred about the invalid `"%s"`  flag in automated tests, and based on the [documentation](https://docs.python.org/3/library/datetime.html#strftime-and-strptime-format-codes). Turns out that the `"%s"` behavior is truly unsupported, and may silently produce incorrect results (see [here](https://stackoverflow.com/a/11743262)). 

The fix implements a more robust method of generating the timestamp using `datetime.timestamp()` (supported by Python 3.3+)