### PR TITLE
Update dependencies: certifi, cryptography, django, scos-actions, scos-tekrsa

### DIFF
--- a/src/requirements-dev.in
+++ b/src/requirements-dev.in
@@ -5,3 +5,8 @@ pytest-cov>=3.0, <4.0
 pytest-django>=4.0, <5.0
 ray[default]>=2.5.0
 tox>=4.0,<5.0
+
+# The following are sub-dependencies for which SCOS Sensor enforces a
+# higher minimum patch version than the dependencies which require them.
+# This is done to ensure the inclusion of specific security patches.
+aiohttp>=3.8.5        # CVE-2023-37276

--- a/src/requirements-dev.txt
+++ b/src/requirements-dev.txt
@@ -359,11 +359,11 @@ scipy==1.10.1
     # via
     #   -r requirements.txt
     #   scos-actions
-scos-actions @ git+https://github.com/NTIA/scos-actions@tagged-unions-processing-info
+scos-actions @ git+https://github.com/NTIA/scos-actions@6.3.2
     # via
     #   -r requirements.txt
     #   scos-tekrsa
-scos-tekrsa @ git+https://github.com/NTIA/scos-tekrsa@scos-actions-6.3.2
+scos-tekrsa @ git+https://github.com/NTIA/scos-tekrsa@3.1.2
     # via -r requirements.txt
 sigmf @ git+https://github.com/NTIA/SigMF@multi-recording-archive
     # via

--- a/src/requirements-dev.txt
+++ b/src/requirements-dev.txt
@@ -358,12 +358,11 @@ scipy==1.10.1
     # via
     #   -r requirements.txt
     #   scos-actions
-scos_actions @ git+https://github.com/NTIA/scos-actions@6.3.1
+scos_actions @ git+https://github.com/NTIA/scos-actions@tagged-unions-processing-info
     # via
     #   -r requirements.txt
     #   scos-tekrsa
-scos_tekrsa @ git+https://github.com/NTIA/scos-tekrsa@3.1.1
-    # via -r requirements.txt
+scos_tekrsa @ git+https://github.com/NTIA/scos-tekrsa@scos-actions-6.3.2
 sigmf @ git+https://github.com/NTIA/SigMF@multi-recording-archive
     # via
     #   -r requirements.txt

--- a/src/requirements-dev.txt
+++ b/src/requirements-dev.txt
@@ -4,8 +4,9 @@
 #
 #    pip-compile requirements-dev.in
 #
-aiohttp==3.8.4
+aiohttp==3.8.5
     # via
+    #   -r requirements-dev.in
     #   aiohttp-cors
     #   ray
 aiohttp-cors==0.7.0
@@ -358,11 +359,12 @@ scipy==1.10.1
     # via
     #   -r requirements.txt
     #   scos-actions
-scos_actions @ git+https://github.com/NTIA/scos-actions@tagged-unions-processing-info
+scos-actions @ git+https://github.com/NTIA/scos-actions@tagged-unions-processing-info
     # via
     #   -r requirements.txt
     #   scos-tekrsa
-scos_tekrsa @ git+https://github.com/NTIA/scos-tekrsa@scos-actions-6.3.2
+scos-tekrsa @ git+https://github.com/NTIA/scos-tekrsa@scos-actions-6.3.2
+    # via -r requirements.txt
 sigmf @ git+https://github.com/NTIA/SigMF@multi-recording-archive
     # via
     #   -r requirements.txt

--- a/src/requirements-dev.txt
+++ b/src/requirements-dev.txt
@@ -318,7 +318,7 @@ pytz==2022.7.1
     #   django
     #   djangorestframework
     #   drf-yasg
-pyyaml==5.4.1
+pyyaml==5.3.1
     # via
     #   -r requirements.txt
     #   docker-compose

--- a/src/requirements-dev.txt
+++ b/src/requirements-dev.txt
@@ -38,7 +38,7 @@ cachetools==5.3.0
     # via
     #   google-auth
     #   tox
-certifi==2022.12.7
+certifi==2023.7.22
     # via
     #   -r requirements.txt
     #   requests
@@ -75,7 +75,7 @@ coreschema==0.0.4
     #   drf-yasg
 coverage[toml]==7.2.1
     # via pytest-cov
-cryptography==41.0.0
+cryptography==41.0.3
     # via
     #   -r requirements.txt
     #   paramiko
@@ -89,7 +89,7 @@ distro==1.8.0
     # via
     #   -r requirements.txt
     #   docker-compose
-django==3.2.19
+django==3.2.20
     # via
     #   -r requirements.txt
     #   django-session-timeout

--- a/src/requirements.in
+++ b/src/requirements.in
@@ -20,5 +20,5 @@ scos_tekrsa @ git+https://github.com/NTIA/scos-tekrsa@scos-actions-6.3.2
 # higher minimum patch version than the dependencies which require them.
 # This is done to ensure the inclusion of specific security patches.
 certifi>=2023.07.22   # CVE-2023-37920
-cryptography>=41.0.2  # CVE-2023-38325
+cryptography>=41.0.3  # GHSA-jm77-qphf-c4w8
 sqlparse>=0.4.4       # CVE-2023-30608

--- a/src/requirements.in
+++ b/src/requirements.in
@@ -22,3 +22,8 @@ scos_tekrsa @ git+https://github.com/NTIA/scos-tekrsa@3.1.2
 certifi>=2023.07.22   # CVE-2023-37920
 cryptography>=41.0.3  # GHSA-jm77-qphf-c4w8
 sqlparse>=0.4.4       # CVE-2023-30608
+
+# PyYAML 5.4 is broken: https://github.com/yaml/pyyaml/issues/724
+# And docker-compose requires <6.0
+# This should be removed once the docker-compose dependency is dropped
+pyyaml==5.3.1

--- a/src/requirements.in
+++ b/src/requirements.in
@@ -13,8 +13,8 @@ psycopg2-binary>=2.0, <3.0
 pyjwt>=2.4.0, <3.0
 requests-mock>=1.0, <2.0
 requests_oauthlib>=1.0, <2.0
-scos_actions @ git+https://github.com/NTIA/scos-actions@tagged-unions-processing-info
-scos_tekrsa @ git+https://github.com/NTIA/scos-tekrsa@scos-actions-6.3.2
+scos_actions @ git+https://github.com/NTIA/scos-actions@6.3.2
+scos_tekrsa @ git+https://github.com/NTIA/scos-tekrsa@3.1.2
 
 # The following are sub-dependencies for which SCOS Sensor enforces a
 # higher minimum patch version than the dependencies which require them.

--- a/src/requirements.in
+++ b/src/requirements.in
@@ -1,4 +1,4 @@
-django>=3.2.19, <4.0
+django>=3.2.20, <4.0
 djangorestframework>=3.0, <4.0
 django-session-timeout>=0.1, <1.0
 docker-compose>=1.0
@@ -19,5 +19,6 @@ scos_tekrsa @ git+https://github.com/NTIA/scos-tekrsa@scos-actions-6.3.2
 # The following are sub-dependencies for which SCOS Sensor enforces a
 # higher minimum patch version than the dependencies which require them.
 # This is done to ensure the inclusion of specific security patches.
-cryptography>=41.0.0  # GHSA-5cpq-8wj7-hf2v
+certifi>=2023.07.22   # CVE-2023-37920
+cryptography>=41.0.2  # CVE-2023-38325
 sqlparse>=0.4.4       # CVE-2023-30608

--- a/src/requirements.in
+++ b/src/requirements.in
@@ -13,8 +13,8 @@ psycopg2-binary>=2.0, <3.0
 pyjwt>=2.4.0, <3.0
 requests-mock>=1.0, <2.0
 requests_oauthlib>=1.0, <2.0
-scos_actions @ git+https://github.com/NTIA/scos-actions@6.3.1
-scos_tekrsa @ git+https://github.com/NTIA/scos-tekrsa@3.1.1
+scos_actions @ git+https://github.com/NTIA/scos-actions@tagged-unions-processing-info
+scos_tekrsa @ git+https://github.com/NTIA/scos-tekrsa@scos-actions-6.3.2
 
 # The following are sub-dependencies for which SCOS Sensor enforces a
 # higher minimum patch version than the dependencies which require them.

--- a/src/requirements.txt
+++ b/src/requirements.txt
@@ -14,7 +14,7 @@ attrs==22.2.0
     #   ray
 bcrypt==4.0.1
     # via paramiko
-certifi==2022.7.22
+certifi==2023.7.22
     # via
     #   -r requirements.in
     #   requests
@@ -180,11 +180,11 @@ ruamel-yaml-clib==0.2.7
     # via ruamel-yaml
 scipy==1.10.1
     # via scos-actions
-scos_actions @ git+https://github.com/NTIA/scos-actions@tagged-unions-processing-info
+scos-actions @ git+https://github.com/NTIA/scos-actions@tagged-unions-processing-info
     # via
     #   -r requirements.in
     #   scos-tekrsa
-scos_tekrsa @ git+https://github.com/NTIA/scos-tekrsa@scos-actions-6.3.2
+scos-tekrsa @ git+https://github.com/NTIA/scos-tekrsa@scos-actions-6.3.2
     # via -r requirements.in
 sigmf @ git+https://github.com/NTIA/SigMF@multi-recording-archive
     # via scos-actions

--- a/src/requirements.txt
+++ b/src/requirements.txt
@@ -178,11 +178,11 @@ ruamel-yaml-clib==0.2.7
     # via ruamel-yaml
 scipy==1.10.1
     # via scos-actions
-scos_actions @ git+https://github.com/NTIA/scos-actions@6.3.1
+scos_actions @ git+https://github.com/NTIA/scos-actions@tagged-unions-processing-info
     # via
     #   -r requirements.in
     #   scos-tekrsa
-scos_tekrsa @ git+https://github.com/NTIA/scos-tekrsa@3.1.1
+scos_tekrsa @ git+https://github.com/NTIA/scos-tekrsa@scos-actions-6.3.2
     # via -r requirements.in
 sigmf @ git+https://github.com/NTIA/SigMF@multi-recording-archive
     # via scos-actions

--- a/src/requirements.txt
+++ b/src/requirements.txt
@@ -14,8 +14,10 @@ attrs==22.2.0
     #   ray
 bcrypt==4.0.1
     # via paramiko
-certifi==2022.12.7
-    # via requests
+certifi==2022.7.22
+    # via
+    #   -r requirements.in
+    #   requests
 cffi==1.15.1
     # via
     #   cryptography
@@ -30,7 +32,7 @@ coreschema==0.0.4
     # via
     #   coreapi
     #   drf-yasg
-cryptography==41.0.0
+cryptography==41.0.3
     # via
     #   -r requirements.in
     #   paramiko
@@ -38,7 +40,7 @@ defusedxml==0.7.1
     # via its-preselector
 distro==1.8.0
     # via docker-compose
-django==3.2.19
+django==3.2.20
     # via
     #   -r requirements.in
     #   django-session-timeout

--- a/src/requirements.txt
+++ b/src/requirements.txt
@@ -180,11 +180,11 @@ ruamel-yaml-clib==0.2.7
     # via ruamel-yaml
 scipy==1.10.1
     # via scos-actions
-scos-actions @ git+https://github.com/NTIA/scos-actions@tagged-unions-processing-info
+scos-actions @ git+https://github.com/NTIA/scos-actions@6.3.2
     # via
     #   -r requirements.in
     #   scos-tekrsa
-scos-tekrsa @ git+https://github.com/NTIA/scos-tekrsa@scos-actions-6.3.2
+scos-tekrsa @ git+https://github.com/NTIA/scos-tekrsa@3.1.2
     # via -r requirements.in
 sigmf @ git+https://github.com/NTIA/SigMF@multi-recording-archive
     # via scos-actions

--- a/src/requirements.txt
+++ b/src/requirements.txt
@@ -153,8 +153,9 @@ pytz==2022.7.1
     #   django
     #   djangorestframework
     #   drf-yasg
-pyyaml==5.4.1
+pyyaml==5.3.1
     # via
+    #   -r requirements.in
     #   docker-compose
     #   ray
 ray==2.5.1


### PR DESCRIPTION
This update patches the following security vulnerabilities by enforcing higher minimum versions on the aiohttp, cryptography, certifi, and django packages:
- GHSA-xqr8-7jwr-rhp7
- GHSA-jh3w-4vvf-mjgr
- GHSA-cf7p-gm2m-833m
- GHSA-jm77-qphf-c4w8
- GHSA-45c4-8wx5-qw6w

This also updates scos-actions to 6.3.2 and scos-tekrsa to 3.1.2, including the SigMF-related changes from NTIA/scos-actions#87

Tested on seadog01