### PR TITLE
Remove deletion of build path files

### DIFF
--- a/scripts/puppet_cleanup.sh
+++ b/scripts/puppet_cleanup.sh
@@ -16,8 +16,6 @@ if [ -e .github ]; then
 fi
 
 rm -f .deployed
-rm -f .github
-rm -f .dockerhub
 
 # Empty environment file
 echo "" > /etc/environment


### PR DESCRIPTION
`.github` and `.dockerhub` in `puppet_cleanup.sh` refer to empty files that would be created during deployment. `.github` is now used as a directory for workflows, so this resolves an issue during deployment where it fails due to attempting to delete that directory as a file. We aren't using this build path paradigm anyway, so let's just drop the deletions.