### PR TITLE
Diagnostics 2.0.0/scos-actions 7.0.0

### DIFF
--- a/src/requirements-dev.txt
+++ b/src/requirements-dev.txt
@@ -325,7 +325,7 @@ scos-actions @ git+https://github.com/NTIA/scos-actions@switch_diagnostics
     # via
     #   -r requirements.txt
     #   scos-tekrsa
-scos-tekrsa @ git+https://github.com/NTIA/scos-tekrsa@3.1.5
+scos-tekrsa @ git+https://github.com/NTIA/scos-tekrsa@switch_diagnostics
     # via -r requirements.txt
 sigmf @ git+https://github.com/NTIA/SigMF@multi-recording-archive
     # via

--- a/src/requirements-dev.txt
+++ b/src/requirements-dev.txt
@@ -321,11 +321,11 @@ scipy==1.10.1
     # via
     #   -r requirements.txt
     #   scos-actions
-scos-actions @ git+https://github.com/NTIA/scos-actions@switch_diagnostics
+scos-actions @ git+https://github.com/NTIA/scos-actions@7.0.0
     # via
     #   -r requirements.txt
     #   scos-tekrsa
-scos-tekrsa @ git+https://github.com/NTIA/scos-tekrsa@switch_diagnostics
+scos-tekrsa @ git+https://github.com/NTIA/scos-tekrsa@4.0.0
     # via -r requirements.txt
 sigmf @ git+https://github.com/NTIA/SigMF@multi-recording-archive
     # via

--- a/src/requirements-dev.txt
+++ b/src/requirements-dev.txt
@@ -142,7 +142,7 @@ inflection==0.5.1
     #   drf-yasg
 iniconfig==2.0.0
     # via pytest
-its-preselector @ git+https://github.com/NTIA/Preselector@3.0.2
+its-preselector @ git+https://github.com/NTIA/Preselector@analog_inputs
     # via
     #   -r requirements.txt
     #   scos-actions
@@ -321,7 +321,7 @@ scipy==1.10.1
     # via
     #   -r requirements.txt
     #   scos-actions
-scos-actions @ git+https://github.com/NTIA/scos-actions@6.4.2
+scos-actions @ git+https://github.com/NTIA/scos-actions@switch_diagnostics
     # via
     #   -r requirements.txt
     #   scos-tekrsa

--- a/src/requirements-dev.txt
+++ b/src/requirements-dev.txt
@@ -142,7 +142,7 @@ inflection==0.5.1
     #   drf-yasg
 iniconfig==2.0.0
     # via pytest
-its-preselector @ git+https://github.com/NTIA/Preselector@analog_inputs
+its-preselector @ git+https://github.com/NTIA/Preselector@3.1.0
     # via
     #   -r requirements.txt
     #   scos-actions

--- a/src/requirements.in
+++ b/src/requirements.in
@@ -13,7 +13,7 @@ psycopg2-binary>=2.0, <3.0
 pyjwt>=2.4.0, <3.0
 requests-mock>=1.0, <2.0
 requests_oauthlib>=1.0, <2.0
-scos_tekrsa @ git+https://github.com/NTIA/scos-tekrsa@3.1.5
+scos_tekrsa @ git+https://github.com/NTIA/scos-tekrsa@switch_diagnostics
 
 # The following are sub-dependencies for which SCOS Sensor enforces a
 # higher minimum patch version than the dependencies which require them.

--- a/src/requirements.in
+++ b/src/requirements.in
@@ -13,7 +13,7 @@ psycopg2-binary>=2.0, <3.0
 pyjwt>=2.4.0, <3.0
 requests-mock>=1.0, <2.0
 requests_oauthlib>=1.0, <2.0
-scos_tekrsa @ git+https://github.com/NTIA/scos-tekrsa@switch_diagnostics
+scos_tekrsa @ git+https://github.com/NTIA/scos-tekrsa@4.0.0
 
 # The following are sub-dependencies for which SCOS Sensor enforces a
 # higher minimum patch version than the dependencies which require them.

--- a/src/requirements.txt
+++ b/src/requirements.txt
@@ -151,7 +151,7 @@ scipy==1.10.1
     # via scos-actions
 scos-actions @ git+https://github.com/NTIA/scos-actions@switch_diagnostics
     # via scos-tekrsa
-scos-tekrsa @ git+https://github.com/NTIA/scos-tekrsa@3.1.5
+scos-tekrsa @ git+https://github.com/NTIA/scos-tekrsa@switch_diagnostics
     # via -r requirements.in
 sigmf @ git+https://github.com/NTIA/SigMF@multi-recording-archive
     # via scos-actions

--- a/src/requirements.txt
+++ b/src/requirements.txt
@@ -65,7 +65,7 @@ idna==3.4
     # via requests
 inflection==0.5.1
     # via drf-yasg
-its-preselector @ git+https://github.com/NTIA/Preselector@3.0.2
+its-preselector @ git+https://github.com/NTIA/Preselector@analog_inputs
     # via scos-actions
 itypes==1.2.0
     # via coreapi
@@ -149,7 +149,7 @@ ruamel-yaml-clib==0.2.8
     # via ruamel-yaml
 scipy==1.10.1
     # via scos-actions
-scos-actions @ git+https://github.com/NTIA/scos-actions@6.4.2
+scos-actions @ git+https://github.com/NTIA/scos-actions@switch_diagnostics
     # via scos-tekrsa
 scos-tekrsa @ git+https://github.com/NTIA/scos-tekrsa@3.1.5
     # via -r requirements.in

--- a/src/requirements.txt
+++ b/src/requirements.txt
@@ -149,9 +149,9 @@ ruamel-yaml-clib==0.2.8
     # via ruamel-yaml
 scipy==1.10.1
     # via scos-actions
-scos-actions @ git+https://github.com/NTIA/scos-actions@switch_diagnostics
+scos-actions @ git+https://github.com/NTIA/scos-actions@7.0.0
     # via scos-tekrsa
-scos-tekrsa @ git+https://github.com/NTIA/scos-tekrsa@switch_diagnostics
+scos-tekrsa @ git+https://github.com/NTIA/scos-tekrsa@4.0.0
     # via -r requirements.in
 sigmf @ git+https://github.com/NTIA/SigMF@multi-recording-archive
     # via scos-actions

--- a/src/requirements.txt
+++ b/src/requirements.txt
@@ -65,7 +65,7 @@ idna==3.4
     # via requests
 inflection==0.5.1
     # via drf-yasg
-its-preselector @ git+https://github.com/NTIA/Preselector@analog_inputs
+its-preselector @ git+https://github.com/NTIA/Preselector@3.1.0
     # via scos-actions
 itypes==1.2.0
     # via coreapi


### PR DESCRIPTION
This updates the format of the diagnostics metadata provided by the nasctn-sea action via scos-actions 7.0.0 (https://github.com/NTIA/scos-actions/pull/101) and updates what states and sensors are expected from the web relays. 

NOTE: this should not be merged until https://github.com/NTIA/scos-tekrsa/pull/51 is merged and released. 