### PR TITLE
Enable log rotation for all containers using Compose file

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,4 @@
-﻿name: scos-sensor
-
-services:
+﻿services:
   db:
     image: postgres:15-alpine
     restart: always

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,4 @@
-﻿version: '3'
+﻿name: scos-sensor
 
 services:
   db:
@@ -16,6 +16,8 @@ services:
       timeout: 3s
       retries: 1
       start_period: 30s
+    logging:
+      driver: local
 
   api:
     healthcheck:
@@ -90,6 +92,8 @@ services:
     extra_hosts:
       - "${MANAGER_FQDN}:${MANAGER_IP}"
     command: /entrypoints/api_entrypoint.sh
+    logging:
+      driver: local
 
   nginx:
     image: smsntia/nginx:${DOCKER_TAG} # DOCKER_TAG will always be 'latest' for GitHub source
@@ -115,6 +119,8 @@ services:
       - ./configs/certs/${SSL_CA_PATH}:/etc/ssl/certs/ca.crt:ro
     environment:
       - DOMAINS
+    logging:
+      driver: local
 
   # This is a stop-gap until Docker adds the capability to restart unhealthy
   # containers natively.
@@ -133,3 +139,5 @@ services:
       - /var/run/docker.sock:/var/run/docker.sock
       - ./entrypoints/autoheal_entrypoint.sh:/entrypoints/autoheal_entrypoint.sh:ro
     command: /entrypoints/autoheal_entrypoint.sh
+    logging:
+      driver: local


### PR DESCRIPTION
Chooses the [recommended `local` logging driver](https://docs.docker.com/config/containers/logging/configure/) to enable automatic log rotation for all containers. Adding this configuration [in the Compose file](https://docs.docker.com/compose/compose-file/05-services/#logging) means that we don't need provisioning solutions to enforce a setting within a sensor's installation of Docker.

This changes the logging driver from `json-file` to `local`, so the log format is changed. The `local` driver defaults to preserving 100 MB of logs per container (5x20MB files). In this configuration, SCOS Sensor logs are capped at 400 MB. Modification of the Compose file can alter these settings per-sensor.

(Finally!) resolves #50.