### PR TITLE
local logging configuration in compose.yml

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -16,8 +16,9 @@ services:
       start_period: 30s
     logging:
         driver: local
-        max-file: 20
-        max-size: 10m
+        options:
+            max-file: 20
+            max-size: 10m
         
 
   api:
@@ -99,8 +100,9 @@ services:
       - "${MANAGER_FQDN}:${MANAGER_IP}"
     logging:
         driver: local
-        max-file: 20
-        max-size: 10m
+        options:
+            max-file: 20
+            max-size: 10m
     command: /entrypoints/api_entrypoint.sh
 
   nginx:
@@ -129,8 +131,9 @@ services:
       - DOMAINS
     logging:
         driver: local
-        max-file: 20
-        max-size: 10m
+        options:
+            max-file: 20
+            max-size: 10m
 
   # This is a stop-gap until Docker adds the capability to restart unhealthy
   # containers natively.

--- a/compose.yaml
+++ b/compose.yaml
@@ -14,6 +14,11 @@ services:
       timeout: 3s
       retries: 1
       start_period: 30s
+    logging:
+        driver: local
+        max-file: 20
+        max-size: 10m
+        
 
   api:
     healthcheck:
@@ -92,6 +97,10 @@ services:
       - /dev/nvme0n1:/dev/nvme0n1:ro
     extra_hosts:
       - "${MANAGER_FQDN}:${MANAGER_IP}"
+    logging:
+        driver: local
+        max-file: 20
+        max-size: 10m
     command: /entrypoints/api_entrypoint.sh
 
   nginx:
@@ -118,6 +127,10 @@ services:
       - ./configs/certs/${SSL_CA_PATH}:/etc/ssl/certs/ca.crt:ro
     environment:
       - DOMAINS
+    logging:
+        driver: local
+        max-file: 20
+        max-size: 10m
 
   # This is a stop-gap until Docker adds the capability to restart unhealthy
   # containers natively.


### PR DESCRIPTION
Update of @aromanielloNTIA pr: https://github.com/NTIA/scos-sensor/pull/283. 
Chooses the [recommended local logging driver](https://docs.docker.com/config/containers/logging/configure/) to enable automatic log rotation for all containers. Adding this configuration [in the Compose file](https://docs.docker.com/compose/compose-file/05-services/#logging) means that we don't need provisioning solutions to enforce a setting within a sensor's installation of Docker.

This changes the logging driver from json-file to local, so the log format is changed. 

(Finally!) resolves https://github.com/NTIA/scos-sensor/issues/50.

This overrides the default local configuration to allow a maximum of 20 10m files. Max file size was reduced to try to be less of a hit on LTE bandwidth and max-files was increased to keep a longer history on the sensor. 